### PR TITLE
Debug product API 500 error

### DIFF
--- a/app/Http/Controllers/Api/V1/BasicController.php
+++ b/app/Http/Controllers/Api/V1/BasicController.php
@@ -10,11 +10,11 @@ use Illuminate\Http\JsonResponse;
 
 class BasicController extends Controller
 {
-    protected $apiResponseService;
+    protected ApiResponseService $apiResponseService;
 
-    public function __construct(ApiResponseService $apiResponseService)
+    public function __construct(ApiResponseService $apiResponseService = null)
     {
-        $this->apiResponseService = $apiResponseService;
+        $this->apiResponseService = $apiResponseService ?? app(ApiResponseService::class);
     }
 
     /**


### PR DESCRIPTION
Make `ApiResponseService` injection robust in `BasicController` to prevent null calls and 500 errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d972df8-cf40-4bb5-aa32-e95fc0877c95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d972df8-cf40-4bb5-aa32-e95fc0877c95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

