### PR TITLE
Agregar PATCH para actualizar datos de un producto

### DIFF
--- a/app/Http/Requests/Producto/UpdateProductoRequest.php
+++ b/app/Http/Requests/Producto/UpdateProductoRequest.php
@@ -16,8 +16,11 @@ class UpdateProductoRequest extends FormRequest
 
     public function rules(): array
     {
+        $isPut = $this->isMethod('put');
+        $required = $isPut ? 'required' : 'sometimes';
+        $productoId = $this->route('id');
 
-        $productId = $this->route('producto') ?? $this->route('id'); // Ajusta según tu ruta
+        //$productId = $this->route('producto') ?? $this->route('id'); // Ajusta según tu ruta
 
         Log::info('=== VALIDANDO REQUEST DE ACTUALIZACIÓN DE PRODUCTO ===');
         Log::info('Request data:', $this->all());
@@ -25,10 +28,10 @@ class UpdateProductoRequest extends FormRequest
 
         return [
 
-            'link' => 'sometimes|required|string|unique:productos,link,' . $productId . '|max:255',
+            'link' => [$required,'string','unique:productos,link,' . $productoId, 'max:255'],
 
-            'nombre' => 'sometimes|required|string|max:255',
-            'titulo' => 'sometimes|required|string|max:255',
+            'nombre' => [$required, 'string', 'max:255'],
+            'titulo' => [$required, 'string', 'max:255'],
             'descripcion' => 'sometimes|nullable|string',
             'seccion' => 'sometimes|nullable|string|max:100',
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -70,6 +70,7 @@ Route::prefix('v1')->group(function () {
 
         Route::middleware(['auth:sanctum', 'role:admin|user'])->group(function () {
             Route::post('/', 'store')->middleware('permission:crear-productos');
+            Route::patch('/{id}', 'update')->middleware('permission:editar-productos');
             Route::put('/{id}', 'update')->middleware('permission:editar-productos');
             Route::delete('/{id}', 'destroy')->middleware('permission:eliminar-productos');
         });


### PR DESCRIPTION
Peticiones de tipo `PUT` se comportaban como `PATCH` (permitía la actualización de un solo campo y no lanzaba un *required* que mencionara que había campos requeridos), incumpliendo la semántica REST.

Se actualizaron las reglas en `UpdateProductRequest`.